### PR TITLE
Fixes #12 Change delimiter from semicolon to comma

### DIFF
--- a/src/scripts/00-directive.js
+++ b/src/scripts/00-directive.js
@@ -31,9 +31,9 @@ angular.module('ngTableExport', [])
                         }
                         if (i != 1) {
                             angular.forEach(tds, function(td, i) {
-                                rowData += csv.stringify(angular.element(td).text()) + ';';
+                                rowData += csv.stringify(angular.element(td).text()) + ',';
                             });
-                            rowData = rowData.slice(0, rowData.length - 1); //remove last semicolon
+                            rowData = rowData.slice(0, rowData.length - 1); //remove last comma
                         }
                         data += rowData + "\n";
                     });


### PR DESCRIPTION
Comma delimited csv is displayed properly in Microsoft Excel as well as in Mac where as semicolon delimited csv files are tricky to open in Microsoft Excel.
